### PR TITLE
Fix return types of the retry decorator function

### DIFF
--- a/retryhttp/_retry.py
+++ b/retryhttp/_retry.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Optional, Sequence, Tuple, Type, Union
 
 from tenacity import (
     RetryCallState,
@@ -25,7 +25,7 @@ from ._wait import wait_context_aware, wait_retry_after
 
 
 def retry(
-    func: Optional[Callable] = None,
+    func: Optional[F] = None,
     *,
     max_attempt_number: int = 3,
     retry_server_errors: bool = True,
@@ -42,7 +42,7 @@ def retry(
     ] = None,
     timeouts: Union[Type[BaseException], Tuple[Type[BaseException], ...], None] = None,
     **kwargs: Any,
-) -> Any:
+) -> F:
     """Retry potentially transient HTTP errors with sensible default behavior.
 
     By default, retries the following errors, for a total of 3 attempts, with

--- a/retryhttp/_utils.py
+++ b/retryhttp/_utils.py
@@ -22,9 +22,9 @@ except ImportError:
     pass
 
 
-def get_default_network_errors() -> (
-    Tuple[Union[Type[httpx.NetworkError], Type[requests.ConnectionError]], ...]
-):
+def get_default_network_errors() -> Tuple[
+    Union[Type[httpx.NetworkError], Type[requests.ConnectionError]], ...
+]:
     """Get all network errors to use by default.
 
     Args:
@@ -56,9 +56,9 @@ def get_default_network_errors() -> (
     return tuple(exceptions)
 
 
-def get_default_timeouts() -> (
-    Tuple[Type[Union[httpx.TimeoutException, requests.Timeout]], ...]
-):
+def get_default_timeouts() -> Tuple[
+    Type[Union[httpx.TimeoutException, requests.Timeout]], ...
+]:
     """Get all timeout exceptions to use by default.
 
     Returns:
@@ -73,9 +73,9 @@ def get_default_timeouts() -> (
     return tuple(exceptions)
 
 
-def get_default_http_status_exceptions() -> (
-    Tuple[Union[Type[httpx.HTTPStatusError], Type[requests.HTTPError]], ...]
-):
+def get_default_http_status_exceptions() -> Tuple[
+    Union[Type[httpx.HTTPStatusError], Type[requests.HTTPError]], ...
+]:
     """Get default HTTP status 4xx or 5xx exceptions.
 
     Returns:


### PR DESCRIPTION
## Changes

* Updated the return type of the `retry` decorator.
* Ran ruff check and fixed code
* Ran run format which updated `__utils` file

## Example

```py
from uuid import UUID
from pydantic import BaseModel
import httpx
from retryhttp._retry import retry

class Payload(BaseModel):
    uuid: UUID
    id: int
    user_id: int
    user_uuid: UUID

@retry()
def get_example() -> Payload:
    response = httpx.get("https://example.com/")
    response.raise_for_status()

    return Payload(**response.json())

get_example().user_uuid
```

Without the code change, you will not get a type hint for `user_uuid` on the last line (`get_example().user_uuid`). With this change, it maintains the return type of the original function.