### PR TITLE
Closes #17: Add default fallback

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.2.1
+## v1.3.0
 
 * Fix typing error ([#15](https://github.com/austind/retryhttp/pull/15))
 * Add default fallback wait strategy [`tenacity.wait_random_exponential`][] to [`retryhttp.wait_from_header`][] and [`retryhttp.wait_retry_after`][] ([#17](https://github.com/austind/retryhttp/pull/))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.1
+
+* Fix typing error ([#15](https://github.com/austind/retryhttp/pull/15))
+* Add default fallback wait strategy [`tenacity.wait_random_exponential`][] to [`retryhttp.wait_from_header`][] and [`retryhttp.wait_retry_after`][] ([#17](https://github.com/austind/retryhttp/pull/))
+
 ## v1.2.0
 
 * Added `wait_max` argument to [`retryhttp.wait_from_header`][] and [`retryhttp.wait_retry_after`][], which defaults to 120.0 seconds.

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -11,7 +11,7 @@ from .conftest import MOCK_URL, scheduled_downtime_response
 
 @retry(
     retry=retry_if_server_error(),
-    wait=wait_from_header(header="Retry-After", wait_max=5),
+    wait=wait_from_header(header="Retry-After", wait_max=5, fallback=None),
     stop=stop_after_attempt(3),
 )
 def planned_downtime_impatient_no_fallback():


### PR DESCRIPTION
Adds default fallback strategy in case the header isn't present or can't be parsed to a float.