### PR TITLE
Avoid forcing installation of both `httpx` and `requests`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Supports both [`requests`](https://docs.python-requests.org/en/latest/index.html
 Install from PyPI:
 
 ```sh
-pip install retryhttp  # Supports both HTTPX and requests
+pip install retryhttp[all]  # Supports both HTTPX and requests
 ```
 
 You can also install support for only HTTPX or requests, if you would rather not install unnecessary dependencies:

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,5 +3,5 @@ import nox
 
 @nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"], tags=["test"])
 def test(session: nox.Session) -> None:
-    session.install(".", ".[dev]")
+    session.install(".[all,dev]")
     session.run("pytest", "-n", "4")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "httpx",
     "pydantic",
-    "requests",
-    "types-requests",
     "tenacity"
 ]
 
@@ -39,12 +36,15 @@ dependencies = [
 [project.optional-dependencies]
 httpx = [
   "httpx",
-  "tenacity",
 ]
 requests = [
   "requests",
   "types-requests",
-  "tenacity",
+]
+all = [
+  "httpx",
+  "requests",
+  "types-requests",
 ]
 dev = [
   "pytest",


### PR DESCRIPTION
Hi, [Apache Airflow](https://github.com/apache/airflow/) committer here 👋 . We are using `retryhttp` as one of our dependency. We found out that when installed, `retryhttp` brings in `requests` too -- which we don't use it in Airflow project -- which adds 30+mb memory footprint as mentioned in [this PR](https://github.com/apache/airflow/pull/56762). While the README.md here says we don't need both httpx and requests -- it still lists both as required deps. This PR fixes it.

Changes:
- Move httpx and requests from core dependencies to optional extras
- Add 'all' extra for users who want both libraries
- Update README to reflect new installation instructions
- Update noxfile to install both extras for testing

Previously, both httpx and requests were always installed even when users only wanted one library. Now users can install only what they need:
- `retryhttp[all]` for both libraries
- `retryhttp[httpx]` for httpx only
- `retryhttp[requests]` for requests only