### PR TITLE
Add support for aiohttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Several HTTP errors are often transient, and might succeed if retried:
 
 This project aims to simplify retrying these, by extending [`tenacity`](https://tenacity.readthedocs.io/) with custom retry and wait strategies, as well as a custom decorator. Defaults are sensible for most use cases, but are fully customizable.
 
-Supports both [`requests`](https://docs.python-requests.org/en/latest/index.html) and [`httpx`](https://python-httpx.org/) natively, but could be customized to use with any library that raises exceptions for the conditions listed above.
+Supports both [`requests`](https://docs.python-requests.org/en/latest/index.html), [`httpx`](https://python-httpx.org/) and [`aiohttp`](https://docs.aiohttp.org/) natively, but could be customized to use with any library that raises exceptions for the conditions listed above.
 
 ## Install
 
 Install from PyPI:
 
 ```sh
-pip install retryhttp  # Supports both HTTPX and requests
+pip install retryhttp  # Supports HTTPX, requests and aiohttp
 ```
 
 You can also install support for only HTTPX or requests, if you would rather not install unnecessary dependencies:
@@ -34,6 +34,7 @@ You can also install support for only HTTPX or requests, if you would rather not
 ```sh
 pip install retryhttp[httpx]  # Supports only HTTPX
 pip install retryhttp[requests]  # Supports only requests
+pip install retryhttp[aiohttp]  # Supports only aiohttp
 ```
 
 Or, install the latest development snapshot from git:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,6 +1,6 @@
 ## Overview
 
-`retryhttp` makes it easy to retry potentially transient HTTP errors when using `httpx` or `requests`.
+`retryhttp` makes it easy to retry potentially transient HTTP errors when using `httpx`, `requests` or `aiohttp`.
 
 !!! note
     Errors that you can safely retry vary from service to service.
@@ -83,4 +83,4 @@ Under the hood, RetryHTTP is a convenience layer on top of the excellent retry l
 
 `tenacity` works by adding a decorator to functions that might fail. This decorator is configured with retry, wait, and stop strategies that configure what conditions to retry, how long to wait between retries, and when to stop retrying, respectively. Failures could be a raised exception, or a configurable return value. See [`tenacity` documentation](https://tenacity.readthedocs.io/en/latest/index.html) for details.
 
-`retryhttp` provides new retry and stop strategies for potentially transient error conditions raised by `httpx` and `requests`. To make things as convenient as possible, `retryhttp` also provides a [new decorator][retryhttp.retry] that wraps [`tenacity.retry`](https://tenacity.readthedocs.io/en/latest/api.html#tenacity.retry) with sensible defaults, which are all customizable.
+`retryhttp` provides new retry and stop strategies for potentially transient error conditions raised by `httpx`, `requests` and `aiohttp`. To make things as convenient as possible, `retryhttp` also provides a [new decorator][retryhttp.retry] that wraps [`tenacity.retry`](https://tenacity.readthedocs.io/en/latest/api.html#tenacity.retry) with sensible defaults, which are all customizable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,14 +17,14 @@ Several HTTP errors are often transient, and might succeed if retried:
 
 This project aims to simplify retrying these, by extending [`tenacity`](https://tenacity.readthedocs.io/) with custom retry and wait strategies, as well as a custom decorator. Defaults are sensible for most use cases, but are fully customizable.
 
-Supports exceptions raised by both [`requests`](https://docs.python-requests.org/en/latest/index.html) and [`httpx`](https://python-httpx.org/).
+Supports exceptions raised by both [`requests`](https://docs.python-requests.org/en/latest/index.html), [`httpx`](https://python-httpx.org/) and [`aiohttp`](https://docs.aiohttp.org/).
 
 ## Install
 
 Install from PyPI:
 
 ```sh
-# Supports both HTTPX and requests
+# Supports HTTPX, requests and aiohttp
 pip install retryhttp
 ```
 
@@ -33,6 +33,7 @@ You can also install support for only HTTPX or requests:
 ```sh
 pip install retryhttp[httpx] # Supports only HTTPX
 pip install retryhttp[requests] # Supports only requests
+pip install retryhttp[aiohttp] # Supports only aiohttp
 ```
 
 Or, install the latest development snapshot from git:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ requests = [
   "types-requests",
   "tenacity",
 ]
+aiohttp = [
+  "aiohttp",
+  "tenacity",
+]
 dev = [
   "pytest",
   "pytest-xdist",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 httpx
 tenacity
 pydantic
+aiohttp
+requests
+types-requests

--- a/retryhttp/_retry.py
+++ b/retryhttp/_retry.py
@@ -87,9 +87,11 @@ def retry(
         - `httpx.WriteError`
         - `requests.ConnectionError`
         - `requests.exceptions.ChunkedEncodingError`
+        - `aiohttp.ClientConnectionError`
     - Timeouts:
         - `httpx.TimeoutException`
         - `requests.Timeout`
+        - `aiohttp.ServerTimeoutError`
 
     Args:
         max_attempt_number: Total times to attempt a request. Includes the first attempt
@@ -112,11 +114,13 @@ def retry(
             - `httpx.WriteError`
             - `requests.ConnectError`
             - `requests.exceptions.ChunkedEncodingError`
+            - `aiohttp.ClientConnectionError`
         timeouts: One or more exceptions that will trigger `wait_timeouts` if
             `retry_timeouts` is `True`. Defaults to:
 
             - `httpx.TimeoutException`
             - `requests.Timeout`
+            - `aiohttp.ServerTimeoutError`
 
     Returns:
         Decorated function.
@@ -181,6 +185,7 @@ class retry_if_network_error(retry_if_exception_type):
             - `httpx.WriteError`
             - `requests.ConnectionError`
             - `requests.exceptions.ChunkedEncodingError`
+            - `aiohttp.ClientConnectionError`
 
     """
 
@@ -237,6 +242,8 @@ class retry_if_timeout(retry_if_exception_type):
             - `httpx.ReadTimeout`
             - `httpx.WriteTimeout`
             - `requests.Timeout`
+            - `aiohttp.ClientConnectionError`
+
     """
 
     def __init__(

--- a/retryhttp/_utils.py
+++ b/retryhttp/_utils.py
@@ -6,6 +6,7 @@ from ._types import HTTPDate
 
 _HTTPX_INSTALLED = False
 _REQUESTS_INSTALLED = False
+_AIOHTTP_INSTALLED = False
 
 try:
     import httpx
@@ -18,6 +19,13 @@ try:
     import requests
 
     _REQUESTS_INSTALLED = True
+except ImportError:
+    pass
+
+try:
+    import aiohttp
+
+    _AIOHTTP_INSTALLED = True
 except ImportError:
     pass
 
@@ -51,6 +59,8 @@ def get_default_network_errors() -> Tuple[Type[BaseException], ...]:
                 requests.exceptions.ChunkedEncodingError,
             ]
         )
+    if _AIOHTTP_INSTALLED:
+        exceptions.append(aiohttp.ClientConnectionError)
     return tuple(exceptions)
 
 
@@ -66,6 +76,8 @@ def get_default_timeouts() -> Tuple[Type[BaseException], ...]:
         exceptions.append(httpx.TimeoutException)
     if _REQUESTS_INSTALLED:
         exceptions.append(requests.Timeout)
+    if _AIOHTTP_INSTALLED:
+        exceptions.append(aiohttp.ServerTimeoutError)
     return tuple(exceptions)
 
 
@@ -81,6 +93,8 @@ def get_default_http_status_exceptions() -> Tuple[Type[BaseException], ...]:
         exceptions.append(httpx.HTTPStatusError)
     if _REQUESTS_INSTALLED:
         exceptions.append(requests.HTTPError)
+    if _AIOHTTP_INSTALLED:
+        exceptions.append(aiohttp.ClientResponseError)
     return tuple(exceptions)
 
 
@@ -99,6 +113,8 @@ def is_rate_limited(exc: Optional[BaseException]) -> bool:
     exceptions = get_default_http_status_exceptions()
     if isinstance(exc, exceptions) and hasattr(exc, "response"):
         return exc.response.status_code == 429
+    if isinstance(exc, exceptions) and hasattr(exc, "status"):  # for aiohttp.ClientResponseError
+        return exc.status == 429
     return False
 
 
@@ -124,6 +140,8 @@ def is_server_error(
     exceptions = get_default_http_status_exceptions()
     if isinstance(exc, exceptions) and hasattr(exc, "response"):
         return exc.response.status_code in status_codes
+    if isinstance(exc, exceptions) and hasattr(exc, "status"):  # for aiohttp.ClientResponseError
+        return exc.status in status_codes
     return False
 
 

--- a/retryhttp/_wait.py
+++ b/retryhttp/_wait.py
@@ -70,24 +70,26 @@ class wait_from_header(wait_base):
             exc = retry_state.outcome.exception()
             if exc is None:
                 return 0
-            if isinstance(exc, get_default_http_status_exceptions()) and hasattr(
-                exc, "response"
-            ):
-                value = exc.response.headers.get(self.header)
-                if value is None:
-                    raise ValueError(f"Header not present: {self.header}")
-                if re.match(r"^\d+$", value):
-                    return float(value)
-                else:
-                    retry_after = datetime.strptime(value, HTTP_DATE_FORMAT)
-                    retry_after = retry_after.replace(tzinfo=timezone.utc)
-                    now = datetime.now(timezone.utc)
-                    if retry_after < now:
-                        raise ValueError(
-                            f'Date provided in header "{self.header}" '
-                            f"is in the past: {value}"
-                        )
-                    return float((retry_after - now).seconds)
+            value = None
+            if isinstance(exc, get_default_http_status_exceptions()):
+                if hasattr(exc, "response"):
+                    value = exc.response.headers.get(self.header)
+                elif hasattr(exc, "status"):  # for aiohttp.ClientResponseError
+                    value = exc.headers.get(self.header)
+            if value is None:
+                raise ValueError(f"Header not present: {self.header}")
+            if re.match(r"^\d+$", value):
+                return float(value)
+            else:
+                retry_after = datetime.strptime(value, HTTP_DATE_FORMAT)
+                retry_after = retry_after.replace(tzinfo=timezone.utc)
+                now = datetime.now(timezone.utc)
+                if retry_after < now:
+                    raise ValueError(
+                        f'Date provided in header "{self.header}" '
+                        f"is in the past: {value}"
+                    )
+                return float((retry_after - now).seconds)
         raise ValueError(f'Unable to parse wait time from header: "{self.header}"')
 
     def __call__(self, retry_state: RetryCallState) -> float:
@@ -162,6 +164,7 @@ class wait_context_aware(wait_base):
             - `httpx.WriteError`
             - `requests.ConnectionError`
             - `requests.exceptions.ChunkedEncodingError`
+            - `aiohttp.ClientConnectionError`
         timeouts: One or more exceptions that will trigger `wait_timeouts`. If omitted,
             defaults to:
 
@@ -169,6 +172,7 @@ class wait_context_aware(wait_base):
             - `httpx.ReadTimeout`
             - `httpx.WriteTimeout`
             - `requests.Timeout`
+            - `aiohttp.ServerTimeoutError`
 
     """
 


### PR DESCRIPTION
closes: #27 

In Apache Airflow we use retryhttp, especially in Edge Worker (https://airflow.apache.org/docs/apache-airflow-providers-edge3/stable/index.html) to ensure communication in stable for long distance HTTP calls.

We would like to enhance the worker client to use async HTTP (see https://github.com/apache/airflow/pull/56457) but the most common aiohttp library (see https://docs.aiohttp.org/) is not supported - yet.

I propose adding this feature.