### PR TITLE
Add Python 3.13 support, drop 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Nox
         uses: wntrblm/nox@2024.04.15
         with:
-          python-versions: "3.8, 3.9, 3.10, 3.11, 3.12"
+          python-versions: "3.9, 3.10, 3.11, 3.12, 3.13"
 
       - name: Run Nox
         run: nox -t test

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"], tags=["test"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"], tags=["test"])
 def test(session: nox.Session) -> None:
     session.install(".", ".[dev]")
     session.run("pytest", "-n", "4")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
Adding Python 3.13 support.
Python 3.8 is not maintained anymore, dropping this.